### PR TITLE
ERROR: failed to build: failed to solve: process "[...]" did not complete successfully: exit code: 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY . .
 
 RUN apk add --update build-base gcompat git libpq-dev libstdc++ mariadb-dev libpq mariadb-connector-c unixodbc yaml-dev && \
     gem install bundler && \
+    bundle lock --normalize-platforms && \
     bundle install && \
     bundle binstubs --all && \
     bundle exec rake assets:precompile && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,10 @@ GEM
     nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.1-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.1-arm-linux-musl)
+      racc (~> 1.4)
     numo-narray (0.9.2.1)
     os (1.1.4)
     pg (1.6.0)
@@ -333,6 +337,8 @@ GEM
     zeitwerk (2.7.4)
 
 PLATFORMS
+  arm-linux-gnu
+  arm-linux-musl
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
The following platform specific gems are getting installed, yet the lockfile includes only their generic ruby version:
* nokogiri-1.19.1-x86_64-linux-musl

Please run `bundle lock --normalize-platforms` and commit the resulting lockfile.
Alternatively, you may run `bundle lock --add-platform <list-of-platforms-that-you-want-to-support>`

*NOTE: this was on x86_64; not sure why the .lock file changes are referencing arm*